### PR TITLE
Service client helper functions.

### DIFF
--- a/include/dr_ros/async_service_client.hpp
+++ b/include/dr_ros/async_service_client.hpp
@@ -12,7 +12,7 @@ template<typename Service>
 class AsyncServiceClient {
 	using Request  = typename Service::Request;
 	using Response = typename Service::Response;
-	using Callback = std::function<void (boost::optional<Response const &>)>;
+	using Callback = std::function<void (std::optional<Response const &>)>;
 
 	ServiceClient<Service> client_;
 	std::thread thread_;
@@ -60,7 +60,7 @@ public:
 				client(request, response, reconnect, timeout, verbose);
 				callback(response);
 			} catch (...) {
-				callback(boost::none);
+				callback(std::nullopt);
 			}
 		});
 	}

--- a/include/dr_ros/service_client.hpp
+++ b/include/dr_ros/service_client.hpp
@@ -41,7 +41,7 @@ public:
 	}
 
 	/// Return a persistent service client.
-	static ServiceClient<Service> makePersitent(
+	static ServiceClient<Service> makePersistent(
 		std::string const & service,
 		bool wait = false,
 		ros::Duration timeout = ros::Duration(-1),
@@ -51,7 +51,7 @@ public:
 	}
 
 	/// Return a non persistent service client.
-	static ServiceClient<Service> makeNonPersitent(
+	static ServiceClient<Service> makeNonPersistent(
 		std::string const & service,
 		bool wait = false,
 		ros::Duration timeout = ros::Duration(-1),


### PR DESCRIPTION
This PR adds two helper functions for creating persistent and non persistent service clients.

It also removes some `boost::optional` in favor of `std::optional`